### PR TITLE
chore Add caching to FlightRepository and update IFlightRepository

### DIFF
--- a/TravelBooking.Domain/IRepository/IFlightRepository.cs
+++ b/TravelBooking.Domain/IRepository/IFlightRepository.cs
@@ -4,7 +4,7 @@ using System.Linq.Expressions;
 public interface IFlightRepository
 {
     Task<Flight?> GetByIdAsync(int id);
-    Task<List<Flight>?> GetByFilterAsync(Expression<Func<Flight, bool>> filterFlight, int take, int skip);
+    Task<List<Flight>?> GetByFilterAsync(Func<Flight, bool> filterFlight, int take, int skip);
     Task<Flight?> GetByFlightNumberAsync(string flightNumber);
     Task<IEnumerable<Flight>> GetAllAsync();
     Task AddAsync(Flight flight);

--- a/TravelBooking.GatewayApi/Program.cs
+++ b/TravelBooking.GatewayApi/Program.cs
@@ -35,6 +35,8 @@ builder.Services.AddValidatorsFromAssemblyContaining<CreatePassengerValidator>()
 builder.Services.AddFluentValidationAutoValidation();
 builder.Services.AddFluentValidationClientsideAdapters();
 
+builder.Services.AddMemoryCache();
+
 builder.Services.AddControllers(options =>
 {
     options.Filters.Add<ValidateModelFilter>();

--- a/TravelBooking.Infrastructure/Repositories/FlightRepository.cs
+++ b/TravelBooking.Infrastructure/Repositories/FlightRepository.cs
@@ -2,32 +2,63 @@
 using TravelBooking.Domain.Entities;
 using TravelBooking.Domain.Interfaces;
 using TravelBooking.Infrastructure.mssql.Persistence;
-using System.Linq.Expressions;
+using Microsoft.Extensions.Caching.Memory;
+
 namespace TravelBooking.Infrastructure.mssql.Repositories;
 
 public class FlightRepository : IFlightRepository
 {
     private readonly TravelBookingDbContext _context;
+    private readonly IMemoryCache _cache;
+    private readonly MemoryCacheEntryOptions _cacheOptions;
 
-    public FlightRepository(TravelBookingDbContext context)
+    public FlightRepository(TravelBookingDbContext context, IMemoryCache cache)
     {
         _context = context;
+        _cache = cache;
+        _cacheOptions = new MemoryCacheEntryOptions
+        {
+            AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5),
+            SlidingExpiration = TimeSpan.FromMinutes(2)
+        };
     }
 
-    public async Task<Flight?> GetByIdAsync(int id) => await _context.Flights.FindAsync(id);
-    
-    public async Task<IEnumerable<Flight>> GetAllAsync() => await _context.Flights.ToListAsync();
+    public async Task<Flight?> GetByIdAsync(int id)
+    {
+        if (!_cache.TryGetValue($"Flight_{id}", out Flight? flight))
+        {
+            flight = await _context.Flights.FindAsync(id);
+            if (flight != null)
+            {
+                _cache.Set($"Flight_{id}", flight, _cacheOptions);
+            }
+        }
+        return flight;
+    }
+
+    public async Task<IEnumerable<Flight>> GetAllAsync()
+    {
+        if (!_cache.TryGetValue("AllFlights", out IEnumerable<Flight>? flights))
+        {
+            flights = await _context.Flights.ToListAsync();
+            _cache.Set("AllFlights", flights, _cacheOptions);
+        }
+        return flights ?? Enumerable.Empty<Flight>();
+    }
 
     public async Task AddAsync(Flight flight)
     {
         _context.Flights.Add(flight);
         await _context.SaveChangesAsync();
+        _cache.Remove("AllFlights");
     }
 
     public async Task UpdateAsync(Flight flight)
     {
         _context.Flights.Update(flight);
         await _context.SaveChangesAsync();
+        _cache.Remove($"Flight_{flight.Id}");
+        _cache.Remove("AllFlights");
     }
 
     public async Task DeleteAsync(int id)
@@ -37,22 +68,32 @@ public class FlightRepository : IFlightRepository
         {
             _context.Flights.Remove(flight);
             await _context.SaveChangesAsync();
+            _cache.Remove($"Flight_{id}");
+            _cache.Remove("AllFlights");
         }
     }
 
-    public async Task<Flight?> GetByFlightNumberAsync(string flightNumber) =>
-    await _context.Flights.Where(flight => flight.FlightNumber.Equals(flightNumber)).FirstOrDefaultAsync();
-
-    public async Task<List<Flight>?> GetByFilterAsync(Expression<Func<Flight, bool>> filterFlight,
-                                                      int take,
-                                                      int skip)
+    public async Task<Flight?> GetByFlightNumberAsync(string flightNumber)
     {
-        return await _context.Flights
-                .Where(filterFlight)
-                .AsNoTracking()
-                .Take(take)
-                .Skip(skip)
-                .ToListAsync();
+        if (!_cache.TryGetValue($"FlightNumber_{flightNumber}", out Flight? flight))
+        {
+            flight = await _context.Flights.Where(f => f.FlightNumber == flightNumber).FirstOrDefaultAsync();
+            if (flight != null)
+            {
+                _cache.Set($"FlightNumber_{flightNumber}", flight, _cacheOptions);
+            }
+        }
+        return flight;
     }
-    
+
+    public async Task<List<Flight>?> GetByFilterAsync(Func<Flight, bool> filterFlight, int take, int skip)
+    {
+        if (!_cache.TryGetValue("AllFlights", out IEnumerable<Flight>? flights))
+        {
+            flights = await _context.Flights.AsNoTracking().ToListAsync();
+            _cache.Set("AllFlights", flights, _cacheOptions);
+        }
+
+        return flights?.Where(filterFlight).Take(take).Skip(skip).ToList() ?? new List<Flight>();
+    }
 }


### PR DESCRIPTION
- Changed `filterFlight` parameter type in `IFlightRepository`'s `GetByFilterAsync` method from `Expression<Func<Flight, bool>>` to `Func<Flight, bool>`.
- Added memory caching to the service collection in `Program.cs` with `builder.Services.AddMemoryCache();`.
- Updated `FlightRepository` to implement caching using `IMemoryCache`:
  - Constructor now accepts an `IMemoryCache` parameter and initializes caching options.
  - `GetByIdAsync`, `GetAllAsync`, and `GetByFlightNumberAsync` methods now check the cache before querying the database and cache the results.
  - `AddAsync`, `UpdateAsync`, and `DeleteAsync` methods now remove relevant cache entries after modifying the database.
  - `GetByFilterAsync` method now checks the cache for all flights before applying the filter and returning the result.