### PR TITLE
Refactor Booking system to use int IDs instead of GUIDs

### DIFF
--- a/TravelBooking.Application/Consumers/BookingCreatedEventConsumer.cs
+++ b/TravelBooking.Application/Consumers/BookingCreatedEventConsumer.cs
@@ -44,7 +44,7 @@ namespace TravelBooking.Application.Consumers
             await _flightRepository.UpdateAsync(flight);
             await _bookingRepository.AddAsync(booking);
 
-            await context.RespondAsync(new CreateBookingResponse
+            await context.RespondAsync(new BookingCreatedEventResponse
             {
                 Success = true,
                 Message = "Booking created successfully",

--- a/TravelBooking.Application/Handlers/Commands/Booking/CreateBookingHandler.cs
+++ b/TravelBooking.Application/Handlers/Commands/Booking/CreateBookingHandler.cs
@@ -10,17 +10,14 @@ public class CreateBookingHandler : IRequestHandler<CreateBookingCommand, Domain
 {
     private readonly IFlightRepository _flightRepository;
     private readonly IPassengerRepository _passengerRepository;
-    private readonly IBus _bus;
     private readonly IRequestClient<BookingCreatedEvent> _client;
 
     public CreateBookingHandler(IFlightRepository flightRepository, 
                                 IPassengerRepository passengerRepository,
-                                IBus bus,
                                 IRequestClient<BookingCreatedEvent> client)
     {
         _flightRepository = flightRepository;
         _passengerRepository = passengerRepository;
-        _bus = bus;
         _client = client;
     }
    
@@ -36,8 +33,8 @@ public class CreateBookingHandler : IRequestHandler<CreateBookingCommand, Domain
             throw new Exception("Flight Not Available Seat.");
 
         var bookingCreated = Domain.Entities.Booking.Create(request.FlightId, request.PassengerId, DateTime.Now, request.SeatCount);
-        var response = await _client.GetResponse<CreateBookingResponse>(bookingCreated.Item2);
-
+        var response = await _client.GetResponse<BookingCreatedEventResponse>(bookingCreated.Item2);
+        bookingCreated.Item1.Id = response.Message.BookingId;
         return bookingCreated.Item1;
     }
 }

--- a/TravelBooking.Common/AutoMappers/AutoMapperProfile.cs
+++ b/TravelBooking.Common/AutoMappers/AutoMapperProfile.cs
@@ -8,7 +8,7 @@ public class AutoMapperProfile : Profile
     public AutoMapperProfile()
     {
         CreateMap<dynamic, BookingDTO>()
-            .ForMember(dest => dest.Id, opt => opt.MapFrom((src, dest) => ConvertToNullableGuid(src, "Id")))
+            .ForMember(dest => dest.Id, opt => opt.MapFrom((src, dest) => ConvertToNullableInt(src, "Id")))
             .ForMember(dest => dest.SeatCount, opt => opt.MapFrom((src, dest) => ConvertToNullableInt(src, "SeatCount")))
             .ForMember(dest => dest.Origin, opt => opt.MapFrom((src, dest) => ConvertToNullableString(src, "Origin")))
             .ForMember(dest => dest.Destination, opt => opt.MapFrom((src, dest) => ConvertToNullableString(src, "Destination")))

--- a/TravelBooking.Common/DTOs/BokingDTOs/BookingDTO.cs
+++ b/TravelBooking.Common/DTOs/BokingDTOs/BookingDTO.cs
@@ -2,7 +2,7 @@
 
 public class BookingDTO
 {
-    public Guid? Id { get; set; }
+    public int? Id { get; set; }
     public DateTime? BookingDate { get; set; }
     public int? SeatCount { get; set; }
 

--- a/TravelBooking.Common/Queries/Booking/GetBookingByIdQuery.cs
+++ b/TravelBooking.Common/Queries/Booking/GetBookingByIdQuery.cs
@@ -1,5 +1,5 @@
 ﻿namespace TravelBooking.Common.Queries.Booking;
 public class GetBookingByIdQuery : IRequest<Domain.Entities.Booking>
 {
-    public Guid? Id { get; set; }
+    public int? Id { get; set; }
 }

--- a/TravelBooking.Domain/Entities/Booking.cs
+++ b/TravelBooking.Domain/Entities/Booking.cs
@@ -4,7 +4,7 @@ namespace TravelBooking.Domain.Entities;
 
 public class Booking
 {
-    public Guid Id { get; set; }
+    public int Id { get; set; }
     public int FlightId { get; set; }
     public int PassengerId { get; set; }
     public DateTime BookingDate { get; set; }
@@ -12,7 +12,7 @@ public class Booking
 
     public Booking() { }
 
-    public Booking(Guid id, int flightId, int passengerId, DateTime bookingDate, int seatCount)
+    public Booking(int id, int flightId, int passengerId, DateTime bookingDate, int seatCount)
     {
         Id = id;
         FlightId = flightId;
@@ -22,7 +22,7 @@ public class Booking
     }
     public static Tuple<Booking, BookingCreatedEvent> Create(int flightId, int passengerId, DateTime bookingDate, int seatCount)
     {
-        var id = Guid.NewGuid();
+        var id = 0;
         var booking = new Booking(id, flightId, passengerId, bookingDate, seatCount);
         var @event = new BookingCreatedEvent(id, flightId, passengerId, bookingDate, seatCount);
 

--- a/TravelBooking.Domain/Events/BookingCreatedEvent.cs
+++ b/TravelBooking.Domain/Events/BookingCreatedEvent.cs
@@ -2,13 +2,13 @@
 {
     public class BookingCreatedEvent
     {
-        public Guid Id { get; set; }
+        public int Id { get; set; }
         public int FlightId { get; set; }
         public int PassengerId { get; set; }
         public DateTime BookingDate { get; set; }
         public int SeatCount { get; set; }
 
-        public BookingCreatedEvent(Guid id, int flightId, int passengerId, DateTime bookingDate, int seatCount)
+        public BookingCreatedEvent(int id, int flightId, int passengerId, DateTime bookingDate, int seatCount)
         {
             Id = id;
             FlightId = flightId;
@@ -16,12 +16,5 @@
             BookingDate = bookingDate;
             SeatCount = seatCount;
         }
-    }
-
-    public class CreateBookingResponse
-    {
-        public bool Success { get; set; }
-        public string Message { get; set; }
-        public Guid BookingId { get; set; }
     }
 }

--- a/TravelBooking.Domain/Events/BookingCreatedEventResponse.cs
+++ b/TravelBooking.Domain/Events/BookingCreatedEventResponse.cs
@@ -1,0 +1,9 @@
+﻿namespace TravelBooking.Domain.Events
+{
+    public class BookingCreatedEventResponse
+    {
+        public bool Success { get; set; }
+        public string Message { get; set; }
+        public int BookingId { get; set; }
+    }
+}

--- a/TravelBooking.Domain/IRepository/IBookingRepository.cs
+++ b/TravelBooking.Domain/IRepository/IBookingRepository.cs
@@ -4,7 +4,7 @@ using TravelBooking.Domain.Entities;
 namespace TravelBooking.Domain.Interfaces;
 
 public interface IBookingRepository { 
-    Task<Booking> GetByIdAsync(Guid id); 
+    Task<Booking> GetByIdAsync(int id); 
     Task<IEnumerable<Booking>> GetAllAsync();
     Task<IEnumerable<dynamic>> GetBookingsAsync(string flightNumber, int take, int skip);
     Task AddAsync(Booking booking); 

--- a/TravelBooking.GatewayApi/Controllers/BookingsController.cs
+++ b/TravelBooking.GatewayApi/Controllers/BookingsController.cs
@@ -20,7 +20,7 @@ public class BookingsController : ControllerBase
     }
 
     [HttpGet("{id}")]
-    public async Task<ActionResult<Booking>> Get(Guid id)
+    public async Task<ActionResult<Booking>> Get(int id)
     {
         var query = new GetBookingByIdQuery { Id = id };
         var Booking = await _mediator.Send(query);

--- a/TravelBooking.Infrastructure/Persistence/Migrations/20250124124423_Init.Designer.cs
+++ b/TravelBooking.Infrastructure/Persistence/Migrations/20250124124423_Init.Designer.cs
@@ -12,7 +12,7 @@ using TravelBooking.Infrastructure.mssql.Persistence;
 namespace TravelBooking.Infrastructure.mssql.Persistence.Migrations
 {
     [DbContext(typeof(TravelBookingDbContext))]
-    [Migration("20250124092840_Init")]
+    [Migration("20250124124423_Init")]
     partial class Init
     {
         /// <inheritdoc />
@@ -27,9 +27,11 @@ namespace TravelBooking.Infrastructure.mssql.Persistence.Migrations
 
             modelBuilder.Entity("TravelBooking.Domain.Entities.Booking", b =>
                 {
-                    b.Property<Guid>("Id")
+                    b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<DateTime>("BookingDate")
                         .HasColumnType("datetime2");
@@ -54,16 +56,16 @@ namespace TravelBooking.Infrastructure.mssql.Persistence.Migrations
                     b.HasData(
                         new
                         {
-                            Id = new Guid("16e455a4-5600-49a5-8df8-f88a579626d1"),
-                            BookingDate = new DateTime(2025, 1, 24, 12, 58, 39, 246, DateTimeKind.Local).AddTicks(389),
+                            Id = 1,
+                            BookingDate = new DateTime(2025, 1, 24, 16, 14, 22, 384, DateTimeKind.Local).AddTicks(1610),
                             FlightId = 1,
                             PassengerId = 1,
                             SeatCount = 1
                         },
                         new
                         {
-                            Id = new Guid("e0f90fcd-3b65-4526-b22f-056b2f0cc3bf"),
-                            BookingDate = new DateTime(2025, 1, 24, 12, 58, 39, 246, DateTimeKind.Local).AddTicks(861),
+                            Id = 2,
+                            BookingDate = new DateTime(2025, 1, 24, 16, 14, 22, 384, DateTimeKind.Local).AddTicks(2649),
                             FlightId = 2,
                             PassengerId = 2,
                             SeatCount = 1
@@ -110,9 +112,9 @@ namespace TravelBooking.Infrastructure.mssql.Persistence.Migrations
                         new
                         {
                             Id = 1,
-                            ArrivalTime = new DateTime(2025, 1, 24, 16, 58, 39, 245, DateTimeKind.Local).AddTicks(192),
+                            ArrivalTime = new DateTime(2025, 1, 24, 20, 14, 22, 382, DateTimeKind.Local).AddTicks(7038),
                             AvailableSeats = 100,
-                            DepartureTime = new DateTime(2025, 1, 24, 14, 58, 39, 243, DateTimeKind.Local).AddTicks(7124),
+                            DepartureTime = new DateTime(2025, 1, 24, 18, 14, 22, 381, DateTimeKind.Local).AddTicks(800),
                             Destination = "Mashhad",
                             FlightNumber = "AB123",
                             Origin = "Tehran",
@@ -121,9 +123,9 @@ namespace TravelBooking.Infrastructure.mssql.Persistence.Migrations
                         new
                         {
                             Id = 2,
-                            ArrivalTime = new DateTime(2025, 1, 24, 19, 58, 39, 245, DateTimeKind.Local).AddTicks(1129),
+                            ArrivalTime = new DateTime(2025, 1, 24, 23, 14, 22, 382, DateTimeKind.Local).AddTicks(8646),
                             AvailableSeats = 150,
-                            DepartureTime = new DateTime(2025, 1, 24, 17, 58, 39, 245, DateTimeKind.Local).AddTicks(1124),
+                            DepartureTime = new DateTime(2025, 1, 24, 21, 14, 22, 382, DateTimeKind.Local).AddTicks(8641),
                             Destination = "Kish",
                             FlightNumber = "CD456",
                             Origin = "Tehran",

--- a/TravelBooking.Infrastructure/Persistence/Migrations/20250124124423_Init.cs
+++ b/TravelBooking.Infrastructure/Persistence/Migrations/20250124124423_Init.cs
@@ -52,7 +52,8 @@ namespace TravelBooking.Infrastructure.mssql.Persistence.Migrations
                 name: "Bookings",
                 columns: table => new
                 {
-                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
                     FlightId = table.Column<int>(type: "int", nullable: false),
                     PassengerId = table.Column<int>(type: "int", nullable: false),
                     BookingDate = table.Column<DateTime>(type: "datetime2", nullable: false),
@@ -80,8 +81,8 @@ namespace TravelBooking.Infrastructure.mssql.Persistence.Migrations
                 columns: new[] { "Id", "ArrivalTime", "AvailableSeats", "DepartureTime", "Destination", "FlightNumber", "Origin", "Price" },
                 values: new object[,]
                 {
-                    { 1, new DateTime(2025, 1, 24, 16, 58, 39, 245, DateTimeKind.Local).AddTicks(192), 100, new DateTime(2025, 1, 24, 14, 58, 39, 243, DateTimeKind.Local).AddTicks(7124), "Mashhad", "AB123", "Tehran", 200.00m },
-                    { 2, new DateTime(2025, 1, 24, 19, 58, 39, 245, DateTimeKind.Local).AddTicks(1129), 150, new DateTime(2025, 1, 24, 17, 58, 39, 245, DateTimeKind.Local).AddTicks(1124), "Kish", "CD456", "Tehran", 300.00m }
+                    { 1, new DateTime(2025, 1, 24, 20, 14, 22, 382, DateTimeKind.Local).AddTicks(7038), 100, new DateTime(2025, 1, 24, 18, 14, 22, 381, DateTimeKind.Local).AddTicks(800), "Mashhad", "AB123", "Tehran", 200.00m },
+                    { 2, new DateTime(2025, 1, 24, 23, 14, 22, 382, DateTimeKind.Local).AddTicks(8646), 150, new DateTime(2025, 1, 24, 21, 14, 22, 382, DateTimeKind.Local).AddTicks(8641), "Kish", "CD456", "Tehran", 300.00m }
                 });
 
             migrationBuilder.InsertData(
@@ -98,8 +99,8 @@ namespace TravelBooking.Infrastructure.mssql.Persistence.Migrations
                 columns: new[] { "Id", "BookingDate", "FlightId", "PassengerId", "SeatCount" },
                 values: new object[,]
                 {
-                    { new Guid("16e455a4-5600-49a5-8df8-f88a579626d1"), new DateTime(2025, 1, 24, 12, 58, 39, 246, DateTimeKind.Local).AddTicks(389), 1, 1, 1 },
-                    { new Guid("e0f90fcd-3b65-4526-b22f-056b2f0cc3bf"), new DateTime(2025, 1, 24, 12, 58, 39, 246, DateTimeKind.Local).AddTicks(861), 2, 2, 1 }
+                    { 1, new DateTime(2025, 1, 24, 16, 14, 22, 384, DateTimeKind.Local).AddTicks(1610), 1, 1, 1 },
+                    { 2, new DateTime(2025, 1, 24, 16, 14, 22, 384, DateTimeKind.Local).AddTicks(2649), 2, 2, 1 }
                 });
 
             migrationBuilder.CreateIndex(

--- a/TravelBooking.Infrastructure/Persistence/Migrations/TravelBookingDbContextModelSnapshot.cs
+++ b/TravelBooking.Infrastructure/Persistence/Migrations/TravelBookingDbContextModelSnapshot.cs
@@ -24,9 +24,11 @@ namespace TravelBooking.Infrastructure.mssql.Persistence.Migrations
 
             modelBuilder.Entity("TravelBooking.Domain.Entities.Booking", b =>
                 {
-                    b.Property<Guid>("Id")
+                    b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<DateTime>("BookingDate")
                         .HasColumnType("datetime2");
@@ -51,16 +53,16 @@ namespace TravelBooking.Infrastructure.mssql.Persistence.Migrations
                     b.HasData(
                         new
                         {
-                            Id = new Guid("16e455a4-5600-49a5-8df8-f88a579626d1"),
-                            BookingDate = new DateTime(2025, 1, 24, 12, 58, 39, 246, DateTimeKind.Local).AddTicks(389),
+                            Id = 1,
+                            BookingDate = new DateTime(2025, 1, 24, 16, 14, 22, 384, DateTimeKind.Local).AddTicks(1610),
                             FlightId = 1,
                             PassengerId = 1,
                             SeatCount = 1
                         },
                         new
                         {
-                            Id = new Guid("e0f90fcd-3b65-4526-b22f-056b2f0cc3bf"),
-                            BookingDate = new DateTime(2025, 1, 24, 12, 58, 39, 246, DateTimeKind.Local).AddTicks(861),
+                            Id = 2,
+                            BookingDate = new DateTime(2025, 1, 24, 16, 14, 22, 384, DateTimeKind.Local).AddTicks(2649),
                             FlightId = 2,
                             PassengerId = 2,
                             SeatCount = 1
@@ -107,9 +109,9 @@ namespace TravelBooking.Infrastructure.mssql.Persistence.Migrations
                         new
                         {
                             Id = 1,
-                            ArrivalTime = new DateTime(2025, 1, 24, 16, 58, 39, 245, DateTimeKind.Local).AddTicks(192),
+                            ArrivalTime = new DateTime(2025, 1, 24, 20, 14, 22, 382, DateTimeKind.Local).AddTicks(7038),
                             AvailableSeats = 100,
-                            DepartureTime = new DateTime(2025, 1, 24, 14, 58, 39, 243, DateTimeKind.Local).AddTicks(7124),
+                            DepartureTime = new DateTime(2025, 1, 24, 18, 14, 22, 381, DateTimeKind.Local).AddTicks(800),
                             Destination = "Mashhad",
                             FlightNumber = "AB123",
                             Origin = "Tehran",
@@ -118,9 +120,9 @@ namespace TravelBooking.Infrastructure.mssql.Persistence.Migrations
                         new
                         {
                             Id = 2,
-                            ArrivalTime = new DateTime(2025, 1, 24, 19, 58, 39, 245, DateTimeKind.Local).AddTicks(1129),
+                            ArrivalTime = new DateTime(2025, 1, 24, 23, 14, 22, 382, DateTimeKind.Local).AddTicks(8646),
                             AvailableSeats = 150,
-                            DepartureTime = new DateTime(2025, 1, 24, 17, 58, 39, 245, DateTimeKind.Local).AddTicks(1124),
+                            DepartureTime = new DateTime(2025, 1, 24, 21, 14, 22, 382, DateTimeKind.Local).AddTicks(8641),
                             Destination = "Kish",
                             FlightNumber = "CD456",
                             Origin = "Tehran",

--- a/TravelBooking.Infrastructure/Repositories/BookingRepository.cs
+++ b/TravelBooking.Infrastructure/Repositories/BookingRepository.cs
@@ -14,7 +14,7 @@ public class BookingRepository : IBookingRepository
         _context = context;
     }
 
-    public async Task<Booking> GetByIdAsync(Guid id)
+    public async Task<Booking> GetByIdAsync(int id)
     {
         return await _context.Bookings.AsNoTracking().FirstOrDefaultAsync(b => b.Id == id) ?? throw new KeyNotFoundException("Booking not found");
     }

--- a/TravelBooking.Infrastructure/SeedsData/ModelBuilderExtensions.cs
+++ b/TravelBooking.Infrastructure/SeedsData/ModelBuilderExtensions.cs
@@ -21,8 +21,8 @@ public static class ModelBuilderExtensions
 
         // Seed data for Bookings
         modelBuilder.Entity<Booking>().HasData(
-            new Booking { Id = Guid.NewGuid(), FlightId = 1, PassengerId = 1, BookingDate = DateTime.Now, SeatCount = 1 },
-            new Booking { Id = Guid.NewGuid(), FlightId = 2, PassengerId = 2, BookingDate = DateTime.Now, SeatCount = 1 }
+            new Booking { Id = 1, FlightId = 1, PassengerId = 1, BookingDate = DateTime.Now, SeatCount = 1 },
+            new Booking { Id = 2, FlightId = 2, PassengerId = 2, BookingDate = DateTime.Now, SeatCount = 1 }
         );
     }
 }


### PR DESCRIPTION
Updated multiple classes to change the `Id` property type from `Guid` to `int` across the Booking system. This includes changes to `Booking`, `BookingDTO`, `GetBookingByIdQuery`, `BookingCreatedEvent`, and related classes. Removed `CreateBookingResponse` class and added `BookingCreatedEventResponse` class. Updated `CreateBookingHandler` to use `IRequestClient<BookingCreatedEvent>` instead of `IBus`. Modified `AutoMapperProfile` to map `Id` property of `BookingDTO` from a nullable integer. Updated `IBookingRepository`, `BookingsController`, and `BookingRepository` to use `int` for `Id` parameters. Removed `20250124092840_Init` migration files and updated `TravelBookingDbContextModelSnapshot` and `ModelBuilderExtensions` for new `Id` type and seed data. Updated tests in `CreateBookingHandlerTests` to reflect these changes.